### PR TITLE
Make consumer timeout configurable

### DIFF
--- a/tap_kafka/__init__.py
+++ b/tap_kafka/__init__.py
@@ -25,7 +25,7 @@ def do_discovery(config):
         consumer = KafkaConsumer(config['topic'],
                                  group_id=config['group_id'],
                                  enable_auto_commit=False,
-                                 consumer_timeout_ms=10000,
+                                 consumer_timeout_ms=config.get('consumer_timeout_ms', 10000),
                                  #value_deserializer=lambda m: json.loads(m.decode('ascii'))
                                  bootstrap_servers=config['bootstrap_servers'].split(','))
     except Exception as ex:

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -60,7 +60,7 @@ def sync_stream(kafka_config, stream, state):
     consumer = KafkaConsumer(kafka_config['topic'],
                              group_id=kafka_config['group_id'],
                              enable_auto_commit=False,
-                             consumer_timeout_ms=10000,
+                             consumer_timeout_ms=kafka_config.get('consumer_timeout_ms', 10000),
                              auto_offset_reset='earliest',
                              value_deserializer=lambda m: json.loads(m.decode('ascii')),
                              bootstrap_servers=kafka_config['bootstrap_servers'])


### PR DESCRIPTION
Simple extra optional config parameter: `consumer_timeout_ms`
Sometimes it's useful to be configurable when starting it from scripts.