### PR TITLE
Feature/add security protocol parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ ENV/
 config.json
 state.json
 properties.json
+
+# VS Code
+.vscode/

--- a/tap_kafka/__init__.py
+++ b/tap_kafka/__init__.py
@@ -22,10 +22,16 @@ def dump_catalog(all_streams):
 
 def do_discovery(config):
     try:
+        # Check if security protocol has been passed to config
+        security_protocol = config.get('security_protocol')
+        if security_protocol is None:
+            security_protocol = "PLAINTEXT"
+
         consumer = KafkaConsumer(config['topic'],
                                  group_id=config['group_id'],
                                  enable_auto_commit=False,
                                  consumer_timeout_ms=config.get('consumer_timeout_ms', 10000),
+                                 security_protocol=security_protocol,
                                  #value_deserializer=lambda m: json.loads(m.decode('ascii'))
                                  bootstrap_servers=config['bootstrap_servers'].split(','))
     except Exception as ex:

--- a/tap_kafka/sync.py
+++ b/tap_kafka/sync.py
@@ -43,7 +43,13 @@ def validate_record(schema, message):
 
 
 def send_reject_message(kafka_config, message, reject_reason):
+    # Check if security protocol has been passed to config
+    security_protocol = config.get('security_protocol')
+    if security_protocol is None:
+        security_protocol = "PLAINTEXT"
+
     producer = KafkaProducer(bootstrap_servers=kafka_config['bootstrap_servers'],
+                             security_protocol=security_protocol,
                              value_serializer=lambda v: json.dumps(v).encode('utf-8'))
 
 
@@ -57,8 +63,14 @@ def send_reject_message(kafka_config, message, reject_reason):
         raise ex
 
 def sync_stream(kafka_config, stream, state):
+    # Check if security protocol has been passed to config
+    security_protocol = kafka_config.get('security_protocol')
+    if security_protocol is None:
+        security_protocol = "PLAINTEXT"
+
     consumer = KafkaConsumer(kafka_config['topic'],
                              group_id=kafka_config['group_id'],
+                             security_protocol=security_protocol,
                              enable_auto_commit=False,
                              consumer_timeout_ms=kafka_config.get('consumer_timeout_ms', 10000),
                              auto_offset_reset='earliest',


### PR DESCRIPTION
# Description of change
 - Added the `security_protocol` parameter to both KafkaConsumer and KafkaProducer to allow passing in "SSL" and avoid a `UnrecognizedBrokerVersion` exception. Code checks for a "security_protocol" key in the config. If it does not find it, it sets `security_protocol` to "PLAINTEXT" which is the default.

# Manual QA steps
 - Attempt connecting to a Kafka cluster using SSL. 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
